### PR TITLE
New device support: Supernote a6x

### DIFF
--- a/cfg/sn_a6x.mos.default.yaml
+++ b/cfg/sn_a6x.mos.default.yaml
@@ -1,0 +1,36 @@
+addlasthalfhour: true
+ampmtime: true
+weekstart: 1
+
+layout:
+  paper:
+    marginparwidth: .8cm
+    marginparsep: .25cm
+    reversemargins: true
+
+    margin:
+      top: 1.5cm
+      left: 1cm
+
+  numbers:
+    dailydiarybest: 3
+    dailydiarygrateful: 3
+    dailydiarylog: 23
+    dailynotes: 22
+    dailybottomhour: 9
+    dailytophour: 18
+    dailytodos: 6
+    dotheightfull: 35
+    dotwidthfull: 29
+    dotwidthtwothirds: 19
+    notesindexpages: 5
+    notesonpage: 22
+    weeklylines: 8
+
+  lengths:
+    headersidequarterswidth: 4cm
+    headersidemonthswidth: 10.45cm
+    lineheightbutline: \dimexpr8mm-.4pt
+    quarterlyspring: \myDummyQ
+    monthlyspring: \vskip.5mm
+    dailyspring: \textcolor{white}{..}

--- a/release.sh
+++ b/release.sh
@@ -9,6 +9,8 @@ _configurations=(
   2 "cfg/base.yaml,cfg/template_months_on_side.yaml,cfg/sn_a5x.mos.default.yaml"                                                "sn_a5x.mos.default"
   2 "cfg/base.yaml,cfg/template_months_on_side.yaml,cfg/sn_a5x.mos.default.yaml,cfg/sn_a5x.mos.default.dailycal.yaml"           "sn_a5x.mos.default.dailycal"
 
+  2 "cfg/base.yaml,cfg/template_months_on_side.yaml,cfg/sn_a6x.mos.default.yaml"                                                "sn_a6x.mos.default"
+
   1 "cfg/base.yaml,cfg/rm2.base.yaml,cfg/template_breadcrumb.yaml,cfg/rm2.breadcrumb.default.yaml"                                          "rm2.breadcrumb.default"
   1 "cfg/base.yaml,cfg/rm2.base.yaml,cfg/template_breadcrumb.yaml,cfg/rm2.breadcrumb.default.yaml,cfg/rm2.breadcrumb.default.dailycal.yaml" "rm2.breadcrumb.default.dailycal"
   2 "cfg/base.yaml,cfg/rm2.base.yaml,cfg/template_months_on_side.yaml,cfg/rm2.mos.default.yaml"                                             "rm2.mos.default"


### PR DESCRIPTION
Thanks for putting this repo together, these planners are extremely useful! I have a Supernote A6x, and had to make some adjustments for the smaller screen size.

This PR doesn't add the breadcrumb or dailycal planners. The a6x screen isn't large enough to support these well. For example, the dailycal can only include ~7 hours above the calendar.

[Sample PDF pages for sn_a6x.mos.dotted.default.2022 pages](https://github.com/kudrykv/latex-yearly-planner/files/9527395/selected-pages-from-sn_a6x.mos.dotted.default.2022.pdf)

[Full PDF sn_a6x.mos.dotted.default.2022.pdf](https://github.com/kudrykv/latex-yearly-planner/files/9527431/sn_a6x.mos.dotted.default.2022.pdf)
