### PR TITLE
device: Add Kindle Scribe, breadcrumb and dailycal

### DIFF
--- a/cfg/kscribe.breadcrumb.default.dailycal.yaml
+++ b/cfg/kscribe.breadcrumb.default.dailycal.yaml
@@ -1,0 +1,7 @@
+calafterschedule: true
+addlasthalfhour: true
+
+layout:
+  numbers:
+    dailybottomhour: 9
+    dailytophour: 21

--- a/cfg/kscribe.breadcrumb.default.yaml
+++ b/cfg/kscribe.breadcrumb.default.yaml
@@ -1,0 +1,26 @@
+layout:
+  paper:
+    width: 15.3cm
+    height: 20.3cm
+
+    margin:
+      top: 0.3cm
+      bottom: 0.3cm
+      left: 0.3cm
+      right: 0.3cm
+
+    reversemargins: true
+    marginparwidth: .8cm
+    marginparsep: 3mm
+
+  lengths:
+    quarterlyspring: \textcolor{white}{.}
+
+  numbers:
+    dailytodos: 6
+    dailynotes: 29
+    dailydiarygoals: 10
+    dailydiarygrateful: 2
+    dailydiarybest: 2
+    dailydiarylog: 30
+    notesonpage: 38

--- a/release.sh
+++ b/release.sh
@@ -25,6 +25,9 @@ _configurations=(
   1 "cfg/base.yaml,cfg/rm2.base.yaml,cfg/rm2_ddvk_lh.base.yaml,cfg/template_breadcrumb.yaml,cfg/rm2.breadcrumb.default.dailycal.yaml" "rm2_ddvk_lh.breadcrumb.default.dailycal"
   2 "cfg/base.yaml,cfg/rm2.base.yaml,cfg/rm2_ddvk_lh.base.yaml,cfg/template_months_on_side.yaml,cfg/rm2.mos.default.yaml"             "rm2_ddvk_lh.mos.default"
   2 "cfg/base.yaml,cfg/rm2.base.yaml,cfg/rm2_ddvk_lh.base.yaml,cfg/template_months_on_side.yaml,cfg/rm2.mos.default.dailycal.yaml"    "rm2_ddvk_lh.mos.default.dailycal"
+
+  1 "cfg/base.yaml,cfg/template_breadcrumb.yaml,cfg/kscribe.breadcrumb.default.yaml,cfg/kscribe.breadcrumb.default.yaml" "kscribe.breadcrumb.default"
+  1 "cfg/base.yaml,cfg/template_breadcrumb.yaml,cfg/kscribe.breadcrumb.default.yaml,cfg/kscribe.breadcrumb.default.dailycal.yaml" "kscribe.breadcrumb.default.dailycal"
 )
 
 _configurations_len=${#_configurations[@]}


### PR DESCRIPTION
Add breadcrumb and breadcrumb.dailycal templates for Kindle Scribe.

Renderings:
* [kscribe.breadcrumb.default.2024.pdf](https://github.com/kudrykv/latex-yearly-planner/files/15278130/kscribe.breadcrumb.default.2024.pdf)
* [kscribe.breadcrumb.default.dailycal.2024.pdf](https://github.com/kudrykv/latex-yearly-planner/files/15278110/kscribe.breadcrumb.default.dailycal.2024.pdf)
