### PR TITLE
Remove invalid option

### DIFF
--- a/single.sh
+++ b/single.sh
@@ -35,7 +35,6 @@ for _ in "${_passes[@]}"; do
     -file-line-error \
     -interaction=nonstopmode \
     -synctex=1 \
-    -output-format=pdf \
     -output-directory=./out \
     "out/${nakedname}.tex"
 done


### PR DESCRIPTION
Get rid of -output-format=pdf since it isn't a valid option for xelatex