### PR TITLE
Add month filter parameter and monthlyplus layout

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -18,6 +18,7 @@ import (
 const (
 	fConfig = "config"
 	pConfig = "preview"
+	fMonth  = "month"
 )
 
 func New() *cli.App {
@@ -30,6 +31,7 @@ func New() *cli.App {
 		Flags: []cli.Flag{
 			&cli.PathFlag{Name: fConfig, Required: true},
 			&cli.BoolFlag{Name: pConfig, Required: false},
+			&cli.IntFlag{Name: fMonth, Required: false, Value: 0},
 		},
 
 		Action: action,
@@ -45,10 +47,15 @@ func action(c *cli.Context) error {
 	)
 
 	preview := c.Bool(pConfig)
+	month := c.Int(fMonth)
 
 	pathConfigs := strings.Split(c.Path(fConfig), ",")
 	if cfg, err = config.New(pathConfigs...); err != nil {
 		return fmt.Errorf("config new: %w", err)
+	}
+
+	if month > 0 {
+		cfg.Month = month
 	}
 
 	wr := &bytes.Buffer{}

--- a/app/compose/monthly.go
+++ b/app/compose/monthly.go
@@ -1,6 +1,8 @@
 package compose
 
 import (
+	"time"
+
 	"github.com/kudrykv/latex-yearly-planner/app/components/cal"
 	"github.com/kudrykv/latex-yearly-planner/app/components/page"
 	"github.com/kudrykv/latex-yearly-planner/app/config"
@@ -12,6 +14,11 @@ func Monthly(cfg config.Config, tpls []string) (page.Modules, error) {
 
 	for _, quarter := range year.Quarters {
 		for _, month := range quarter.Months {
+			// Skip months if month filter is set and doesn't match
+			if cfg.Month > 0 && month.Month != time.Month(cfg.Month) {
+				continue
+			}
+
 			modules = append(modules, page.Module{
 				Cfg: cfg,
 				Tpl: tpls[0],

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	Debug Debug
 
 	Year                int `env:"PLANNER_YEAR"`
+	Month               int `env:"PLANNER_MONTH"`
 	WeekStart           time.Weekday
 	Dotted              bool
 	CalAfterSchedule    bool

--- a/cfg/kscribe.breadcrumb.monthlyplus.yaml
+++ b/cfg/kscribe.breadcrumb.monthlyplus.yaml
@@ -1,0 +1,52 @@
+layout:
+  paper:
+    width: 15.3cm
+    height: 20.3cm
+
+    margin:
+      top: 0.3cm
+      bottom: 0.3cm
+      left: 0.3cm
+      right: 0.3cm
+
+    reversemargins: true
+    marginparwidth: .8cm
+    marginparsep: 3mm
+
+  lengths:
+    quarterlyspring: \textcolor{white}{.}
+
+  numbers:
+    dailytodos: 6
+    dailynotes: 29
+    dailydiarygoals: 10
+    dailydiarygrateful: 2
+    dailydiarybest: 2
+    dailydiarylog: 30
+    notesonpage: 38
+
+pages:
+  - name: title
+    renderblocks:
+      - funcname: title
+        tpls:
+          - title.tpl
+
+  - name: monthly
+    renderblocks:
+      - funcname: monthly
+        tpls:
+          - breadcrumb_03_monthly.tpl
+
+  - name: weekly
+    renderblocks:
+      - funcname: weekly
+        tpls:
+          - breadcrumb_04_weekly.tpl
+
+  - name: notes_indexed
+    renderblocks:
+      - funcname: notes_indexed
+        tpls:
+          - breadcrumb_08_notes_index.tpl
+          - breadcrumb_09_notes.tpl

--- a/single.sh
+++ b/single.sh
@@ -9,10 +9,15 @@ else
   echo "Building using plannergen binary at \"${PLANNERGEN_BINARY}\""
 fi
 
+MONTH_FLAG=""
+if [ -n "$PLANNER_MONTH" ]; then
+  MONTH_FLAG="--month $PLANNER_MONTH"
+fi
+
 if [ -z "$PREVIEW" ]; then
-  eval $GO_CMD --config "${CFG}"
+  eval $GO_CMD --config "${CFG}" $MONTH_FLAG
 else
-  eval $GO_CMD --preview --config "${CFG}"
+  eval $GO_CMD --preview --config "${CFG}" $MONTH_FLAG
 fi
 
 


### PR DESCRIPTION
- Add --month flag to CLI for filtering by month (1-12)
- Add Month field to Config struct with PLANNER_MONTH env var support
- Implement month filtering in Monthly composer
- Update single.sh to pass month parameter to plannergen
- Create kscribe.breadcrumb.monthlyplus.yaml layout with title, monthly, weekly, and notes